### PR TITLE
Implement partnership API and fix chat typing

### DIFF
--- a/client/src/components/chatbot.tsx
+++ b/client/src/components/chatbot.tsx
@@ -12,7 +12,7 @@ export default function Chatbot() {
   const [sessionId] = useState(() => Math.random().toString(36).substring(7));
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  const { data: messages = [], refetch } = useQuery({
+  const { data: messages = [], refetch } = useQuery<ChatMessage[]>({
     queryKey: [`/api/chat/${sessionId}`],
     enabled: isOpen
   });
@@ -59,7 +59,7 @@ export default function Chatbot() {
   };
 
   // Initial bot message for new sessions
-  const initialMessage = {
+  const initialMessage: ChatMessage = {
     id: 0,
     message: "Hello! I'm here to help answer questions about Coconut Luxembourg and our youth empowerment programs. How can I assist you today?",
     isUser: false,
@@ -67,7 +67,7 @@ export default function Chatbot() {
     createdAt: new Date()
   };
 
-  const allMessages = messages.length === 0 ? [initialMessage] : messages;
+  const allMessages: ChatMessage[] = messages.length === 0 ? [initialMessage] : messages;
 
   return (
     <div className="fixed bottom-6 right-6 z-50">

--- a/client/src/pages/partnerships.tsx
+++ b/client/src/pages/partnerships.tsx
@@ -245,11 +245,8 @@ export default function PartnershipsPage() {
 
   const partnershipMutation = useMutation({
     mutationFn: async (data: PartnershipFormData) => {
-      return apiRequest("/api/partnership", {
-        method: "POST",
-        body: JSON.stringify(data),
-        headers: { "Content-Type": "application/json" },
-      });
+      const response = await apiRequest("POST", "/api/partnership", data);
+      return response.json();
     },
     onSuccess: () => {
       toast({
@@ -258,7 +255,7 @@ export default function PartnershipsPage() {
       });
       form.reset();
     },
-    onError: (error) => {
+    onError: () => {
       toast({
         title: "Submission failed",
         description: "Please try again or contact us directly.",

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,7 +1,7 @@
 import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
-import { insertContactMessageSchema, insertChatMessageSchema } from "@shared/schema";
+import { insertContactMessageSchema, insertChatMessageSchema, insertPartnershipMessageSchema } from "@shared/schema";
 import { z } from "zod";
 
 export async function registerRoutes(app: Express): Promise<Server> {
@@ -12,6 +12,21 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const contactData = insertContactMessageSchema.parse(req.body);
       const message = await storage.createContactMessage(contactData);
       res.json({ success: true, message: "Contact message received successfully", id: message.id });
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        res.status(400).json({ message: "Invalid input data", errors: error.errors });
+      } else {
+        res.status(500).json({ message: "Internal server error" });
+      }
+    }
+  });
+
+  // Partnership inquiries
+  app.post("/api/partnership", async (req, res) => {
+    try {
+      const partnershipData = insertPartnershipMessageSchema.parse(req.body);
+      const message = await storage.createPartnershipMessage(partnershipData);
+      res.json({ success: true, message: "Partnership request received successfully", id: message.id });
     } catch (error) {
       if (error instanceof z.ZodError) {
         res.status(400).json({ message: "Invalid input data", errors: error.errors });

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,4 +1,4 @@
-import { users, contactMessages, chatMessages, type User, type InsertUser, type ContactMessage, type InsertContactMessage, type ChatMessage, type InsertChatMessage } from "@shared/schema";
+import { users, contactMessages, chatMessages, partnershipMessages, type User, type InsertUser, type ContactMessage, type InsertContactMessage, type ChatMessage, type InsertChatMessage, type PartnershipMessage, type InsertPartnershipMessage } from "@shared/schema";
 
 export interface IStorage {
   getUser(id: number): Promise<User | undefined>;
@@ -7,23 +7,29 @@ export interface IStorage {
   createContactMessage(message: InsertContactMessage): Promise<ContactMessage>;
   getChatMessages(sessionId: string): Promise<ChatMessage[]>;
   createChatMessage(message: InsertChatMessage): Promise<ChatMessage>;
+  getPartnershipMessages(): Promise<PartnershipMessage[]>;
+  createPartnershipMessage(message: InsertPartnershipMessage): Promise<PartnershipMessage>;
 }
 
 export class MemStorage implements IStorage {
   private users: Map<number, User>;
   private contactMessages: Map<number, ContactMessage>;
   private chatMessages: Map<number, ChatMessage>;
+  private partnershipMessages: Map<number, PartnershipMessage>;
   private currentUserId: number;
   private currentContactId: number;
   private currentChatId: number;
+  private currentPartnershipId: number;
 
   constructor() {
     this.users = new Map();
     this.contactMessages = new Map();
     this.chatMessages = new Map();
+    this.partnershipMessages = new Map();
     this.currentUserId = 1;
     this.currentContactId = 1;
     this.currentChatId = 1;
+    this.currentPartnershipId = 1;
   }
 
   async getUser(id: number): Promise<User | undefined> {
@@ -68,6 +74,23 @@ export class MemStorage implements IStorage {
       createdAt: new Date() 
     };
     this.chatMessages.set(id, message);
+    return message;
+  }
+
+  async getPartnershipMessages(): Promise<PartnershipMessage[]> {
+    return Array.from(this.partnershipMessages.values())
+      .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  }
+
+  async createPartnershipMessage(insertMessage: InsertPartnershipMessage): Promise<PartnershipMessage> {
+    const id = this.currentPartnershipId++;
+    const message: PartnershipMessage = {
+      ...insertMessage,
+      website: insertMessage.website ?? null,
+      id,
+      createdAt: new Date()
+    };
+    this.partnershipMessages.set(id, message);
     return message;
   }
 }

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -2,6 +2,7 @@ import express, { type Express } from "express";
 import fs from "fs";
 import path from "path";
 import { createServer as createViteServer, createLogger } from "vite";
+import type { ServerOptions } from "vite";
 import { type Server } from "http";
 import viteConfig from "../vite.config";
 import { nanoid } from "nanoid";
@@ -24,7 +25,7 @@ export async function setupVite(app: Express, server: Server) {
     middlewareMode: true,
     hmr: { server },
     allowedHosts: true,
-  };
+  } satisfies ServerOptions;
 
   const vite = await createViteServer({
     ...viteConfig,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -54,9 +54,16 @@ export const insertChatMessageSchema = createInsertSchema(chatMessages).omit({
   createdAt: true,
 });
 
+export const insertPartnershipMessageSchema = createInsertSchema(partnershipMessages).omit({
+  id: true,
+  createdAt: true,
+});
+
 export type InsertUser = z.infer<typeof insertUserSchema>;
 export type User = typeof users.$inferSelect;
 export type ContactMessage = typeof contactMessages.$inferSelect;
 export type InsertContactMessage = z.infer<typeof insertContactMessageSchema>;
 export type ChatMessage = typeof chatMessages.$inferSelect;
 export type InsertChatMessage = z.infer<typeof insertChatMessageSchema>;
+export type PartnershipMessage = typeof partnershipMessages.$inferSelect;
+export type InsertPartnershipMessage = z.infer<typeof insertPartnershipMessageSchema>;


### PR DESCRIPTION
## Summary
- add a partnership submission schema, storage helpers, and express route so partnership requests are stored like contact messages
- update the partnerships page mutation to call the new endpoint through the shared apiRequest helper
- tighten chatbot React Query types and fix vite server options typing for successful type checks

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_b_68d149d8e9348333bfe403a2acacd94c